### PR TITLE
Development servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 
-- `tna-run` uses Django and Flask development servers if `$ENVIRONMENT == develop`
+- `tna-run` tries to use Django or Flask development servers if `$ENVIRONMENT == develop`, reverting to `gunicorn` if neither are available
+- Updated Gunicorn to [21.2.0](https://github.com/benoitc/gunicorn/releases/tag/21.2.0)
 
 ### Deprecated
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Changed
+
+- `tna-run` uses Django and Flask development servers if `$ENVIRONMENT == develop`
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/docker/tna-python/bin/tna-build
+++ b/docker/tna-python/bin/tna-build
@@ -16,10 +16,8 @@ fi
 
 if [ -n "$NPM_BUILD_COMMAND" ]
 then
-  # npm install --omit=dev
   tna-node "$NPM_BUILD_COMMAND"
-  # rm -fR node_modules
 fi
 
-poetry add gunicorn@21.1.0
+poetry add gunicorn@21.2.0
 poetry install --sync --no-root

--- a/docker/tna-python/bin/tna-run
+++ b/docker/tna-python/bin/tna-run
@@ -33,7 +33,7 @@ then
   if poetry show django ;
   then
     echo "Django module found"
-    poetry run python manage.py runserver 0.0.0.0:8080
+    poetry run python /app/manage.py runserver 0.0.0.0:8080
   elif poetry show flask ;
   then
     echo "Flask module found"

--- a/docker/tna-python/bin/tna-run
+++ b/docker/tna-python/bin/tna-run
@@ -30,22 +30,27 @@ then
   poetry run gunicorn "$1" --workers "$WORKERS" --threads "$THREADS" --log-level "$LOG_LEVEL" --timeout "$TIMEOUT" --keep-alive "$KEEP_ALIVE" --access-logfile - --bind 0.0.0.0:8080
 elif [ "$ENVIRONMENT" == 'develop' ]
 then
+  echo "ENVIRONMENT is develop"
+  echo "Trying Django development server..."
   if poetry show django ;
   then
-    echo "Django module found"
+    echo "Django found, starting server"
     poetry run python /app/manage.py runserver 0.0.0.0:8080
-  elif poetry show flask ;
-  then
-    echo "Flask module found"
-    poetry run flask run --debug --host 0.0.0.0 --port 8080
-  else
-    echo "No framework found, using Gunicorn to serve development application"
-    [[ -z $LOG_LEVEL ]] && LOG_LEVEL=debug
-    [[ -z $WORKERS ]] && WORKERS=3
-    [[ -z $TIMEOUT ]] && TIMEOUT=600
-    [[ -z $KEEP_ALIVE ]] && KEEP_ALIVE=5
-    poetry run gunicorn "$1" --workers "$WORKERS" --threads "$THREADS" --log-level "$LOG_LEVEL" --timeout "$TIMEOUT" --keep-alive "$KEEP_ALIVE" --reload --bind 0.0.0.0:8080
   fi
+  echo "Django not found"
+  echo "Trying Flask development server..."
+  if poetry show flask ;
+  then
+    echo "Flask found, starting server"
+    poetry run flask run --debug --host 0.0.0.0 --port 8080
+  fi
+  echo "Flask not found"
+  echo "No framework found, using Gunicorn to serve development application"
+  [[ -z $LOG_LEVEL ]] && LOG_LEVEL=debug
+  [[ -z $WORKERS ]] && WORKERS=3
+  [[ -z $TIMEOUT ]] && TIMEOUT=600
+  [[ -z $KEEP_ALIVE ]] && KEEP_ALIVE=5
+  poetry run gunicorn "$1" --workers "$WORKERS" --threads "$THREADS" --log-level "$LOG_LEVEL" --timeout "$TIMEOUT" --keep-alive "$KEEP_ALIVE" --reload --bind 0.0.0.0:8080
 else
   [[ -z $LOG_LEVEL ]] && LOG_LEVEL=info
   [[ -z $WORKERS ]] && WORKERS=$DEFAULT_WORKERS

--- a/docker/tna-python/bin/tna-run
+++ b/docker/tna-python/bin/tna-run
@@ -30,12 +30,22 @@ then
   poetry run gunicorn "$1" --workers "$WORKERS" --threads "$THREADS" --log-level "$LOG_LEVEL" --timeout "$TIMEOUT" --keep-alive "$KEEP_ALIVE" --access-logfile - --bind 0.0.0.0:8080
 elif [ "$ENVIRONMENT" == 'develop' ]
 then
-  [[ -z $LOG_LEVEL ]] && LOG_LEVEL=debug
-  [[ -z $WORKERS ]] && WORKERS=3
-  [[ -z $TIMEOUT ]] && TIMEOUT=600
-  [[ -z $KEEP_ALIVE ]] && KEEP_ALIVE=5
-  poetry run gunicorn "$1" --workers "$WORKERS" --threads "$THREADS" --log-level "$LOG_LEVEL" --timeout "$TIMEOUT" --keep-alive "$KEEP_ALIVE" --reload --bind 0.0.0.0:8080
-  # poetry run python manage.py runserver 0.0.0.0:8080
+  if poetry show django ;
+  then
+    echo "Django module found"
+    poetry run python manage.py runserver 0.0.0.0:8080
+  elif poetry show flask ;
+  then
+    echo "Flask module found"
+    poetry run flask run --debug --host 0.0.0.0 --port 8080
+  else
+    echo "No framework found, using Gunicorn to serve development application"
+    [[ -z $LOG_LEVEL ]] && LOG_LEVEL=debug
+    [[ -z $WORKERS ]] && WORKERS=3
+    [[ -z $TIMEOUT ]] && TIMEOUT=600
+    [[ -z $KEEP_ALIVE ]] && KEEP_ALIVE=5
+    poetry run gunicorn "$1" --workers "$WORKERS" --threads "$THREADS" --log-level "$LOG_LEVEL" --timeout "$TIMEOUT" --keep-alive "$KEEP_ALIVE" --reload --bind 0.0.0.0:8080
+  fi
 else
   [[ -z $LOG_LEVEL ]] && LOG_LEVEL=info
   [[ -z $WORKERS ]] && WORKERS=$DEFAULT_WORKERS


### PR DESCRIPTION
- `tna-run` tries to use Django or Flask development servers if `$ENVIRONMENT == develop`, reverting to `gunicorn` if neither are available
- Updated Gunicorn to [21.2.0](https://github.com/benoitc/gunicorn/releases/tag/21.2.0)